### PR TITLE
firestore saves scenes metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The `npm run sandbox` will run `ts-node` on your sandbox typescript file, handle
 Always be verifying things work in development before ever porting it over to firebase functions.
 
 ## To Do
-1. Fix `analyzeSceneShots` Error: ENOENT: no such file or directory, stat '/tmp/0'. Might be related to fs.readFile [race condition](https://stackoverflow.com/questions/60984659/error-enoent-no-such-file-or-directory-even-when-file-exists-in-firebase-cloud)
-2. Move out dev API keys to environment variables
-3. Test it in production
+1. Finish `functions/src/fn/addToDatabase/addToDatabase.fn.ts`
+2. Add firestore.save() when a user uploads a raw source video
+3. Clean up code to be more readable
+4. Move out dev API keys to firebase-style environment variables
+5. Test it in production

--- a/functions/src/@api/analyze.api.ts
+++ b/functions/src/@api/analyze.api.ts
@@ -3,14 +3,15 @@
  * ---------------------------
  */
 import { protos } from "@google-cloud/video-intelligence";
-import type { IUserVideoId, ILabeledScene } from "@customTypes/types.spec";
+import type { ILabeledScene } from "@customTypes/types.spec";
 
+// PLACEHOLDER
 export const createLabeledScenesForSearch = async (
   annotations: protos.google.cloud.videointelligence.v1.AnnotateVideoResponse,
-  { videoId, userId, sceneId }: IUserVideoId
+  sceneId: string
 ): Promise<ILabeledScene[]> => {
-  // console.log(annotations);
-  console.log(videoId, userId, sceneId);
+  console.log(annotations);
+  console.log(sceneId);
   if (sceneId) {
     return [{ sceneId }];
   }

--- a/functions/src/@api/sceneUploader.api.ts
+++ b/functions/src/@api/sceneUploader.api.ts
@@ -92,13 +92,43 @@ export const extractValidScenes = async ({
 export const uploadSceneToBucket = async (
   sceneId: TSceneId,
   scenePath: string
-): Promise<void> => {
+): Promise<string> => {
   console.log(sceneId);
   console.log(scenePath);
   const destination = `scene/${sceneId}/${sceneId}.mp4`;
   await admin.storage().bucket(SCENE_VIDEOS_CLOUD_BUCKET).upload(scenePath, {
     destination,
   });
+  return destination;
+};
+
+interface ISceneSave {
+  sceneId: string;
+  userId: string;
+  videoId: string;
+  destination: string;
+}
+export const saveSceneToFirestore = async ({
+  sceneId,
+  userId,
+  videoId,
+  destination,
+}: ISceneSave): Promise<void> => {
+  await admin.firestore().collection("scenes").doc(sceneId).set(
+    {
+      sceneId,
+      originalUploaderId: userId,
+      originalVideoId: videoId,
+      destinationStorageUrl: destination,
+    },
+    { merge: true }
+  );
+  return;
+};
+
+// PLACEHOLDER
+// save firestore record of user uploading a raw source video
+export const recordVideoUploadedByUser = async (): Promise<void> => {
   return;
 };
 

--- a/functions/src/fn/addToDatabase/addToDatabase.fn.ts
+++ b/functions/src/fn/addToDatabase/addToDatabase.fn.ts
@@ -24,10 +24,8 @@ const addToDatabase = functions.storage
     log("1b. object: ", object);
     const filePath = object?.name || "";
     log("1b. filePath: ", filePath);
-    const { videoId, userId, sceneId } = extractRelevantIds(filePath);
-    log(
-      `2b. relevantIds: videoId=${videoId}, userId=${userId}, sceneId=${sceneId}`
-    );
+    const { sceneId } = extractRelevantIds(filePath);
+    log(`2b. relevantIds: sceneId=${sceneId}`);
     // Locally download the json file created by the vision API
     if (filePath && sceneId) {
       // locally download the metadata json
@@ -43,11 +41,7 @@ const addToDatabase = functions.storage
         camelize(JSON.parse(fs.readFileSync(tempFilePathAnnotations, "utf-8")));
       log("3b. Annotations: ", annotations);
       // process the labels & scenes into a queryable schema
-      const labeledScenes = createLabeledScenesForSearch(annotations, {
-        videoId,
-        userId,
-        sceneId,
-      });
+      const labeledScenes = createLabeledScenesForSearch(annotations, sceneId);
       log("4. Labels: ", labeledScenes);
       log("4b. Uploading to firestore...");
       // upload the labeled scenes to firestore


### PR DESCRIPTION
When thumbnails get created for a scene, a reference entry is saved to firestore db so that we can get all the original data about this scene. Such as:
- userId of original uploader
- videoId of source video
- sceneId
- location of all the thumbnails