### PR TITLE
Video render optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ gcloud config unset auth/impersonate_service_account
 3. Potentially add React.useBoundingBox to exclude JS rendering of videos outside the current window display.
 4. Might benefit from React.useRef to delete videos
 3. Add dark theme with React.useContext
-4. Improve results rendering. Too many videos playing all at once. Potentially improve frontend rendering with React.useMemo on video HTML, or just use thumbnails
 3. Write tests when ironed out
 2. Write declarative firebase infrastructure config files with alias environment variables
 ## Optimizations

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ gcloud config unset auth/impersonate_service_account
 
 ## To Do
 1. Clean up code to be more readable
-2. Refactor MostRecentSceneResults to de-couple the GQL and the ResultsList
 3. Potentially add React.useBoundingBox to exclude JS rendering of videos outside the current window display.
 4. Might benefit from React.useRef to delete videos
 3. Add dark theme with React.useContext

--- a/frontend/src/@components/scenes-list/index.tsx
+++ b/frontend/src/@components/scenes-list/index.tsx
@@ -1,6 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
+import { Fragment } from "react";
 import { useMediaQuery } from "react-responsive";
 import VideoCard from "@components/video-card";
 import { List } from "antd";
@@ -12,17 +13,21 @@ interface IProps {
 const ScenesList = ({ scenes }: IProps) => {
   const isPortrait = useMediaQuery({ orientation: "portrait" });
   return (
-    <List
-      grid={isPortrait ? { gutter: 16, column: 2 } : { gutter: 16, column: 4 }}
-      dataSource={scenes}
-      renderItem={(item: Scene) => {
-        return (
-          <List.Item>
-            <VideoCard item={item} />
-          </List.Item>
-        );
-      }}
-    />
+    <Fragment>
+      <List
+        grid={
+          isPortrait ? { gutter: 16, column: 2 } : { gutter: 16, column: 4 }
+        }
+        dataSource={scenes}
+        renderItem={(item: Scene) => {
+          return (
+            <List.Item>
+              <VideoCard item={item} />
+            </List.Item>
+          );
+        }}
+      />
+    </Fragment>
   );
 };
 

--- a/frontend/src/@components/video-card/index.tsx
+++ b/frontend/src/@components/video-card/index.tsx
@@ -44,6 +44,7 @@ const VideoCard = ({ item }: IProps) => {
       hoverable
       cover={
         <VideoPlayer
+          sceneId={item.sceneId}
           options={videoPlayerOptions(item)}
           thumbnail={item.thumbnails && item.thumbnails[0]}
           videoSrc={item.publicUrl}

--- a/frontend/src/@components/video-card/index.tsx
+++ b/frontend/src/@components/video-card/index.tsx
@@ -42,7 +42,13 @@ const VideoCard = ({ item }: IProps) => {
     <Card
       key={item.sceneId}
       hoverable
-      cover={<VideoPlayer options={videoPlayerOptions(item)} />}
+      cover={
+        <VideoPlayer
+          options={videoPlayerOptions(item)}
+          thumbnail={item.thumbnails && item.thumbnails[0]}
+          videoSrc={item.publicUrl}
+        />
+      }
       actions={[
         <div css={styles.action}>
           <LikeFilled key="like" />

--- a/frontend/src/@components/videoplayer/index.tsx
+++ b/frontend/src/@components/videoplayer/index.tsx
@@ -50,11 +50,9 @@ const VideoPlayer: React.FC<IVideoPlayerProps> = ({
         if (entry.target.id === videoPlayerWrapperId) {
           if (entry.isIntersecting) {
             videoNode.current?.play();
+          } else if (!videoNode.current?.paused) {
+            videoNode.current?.pause();
           }
-          // fix this paused identifier specific to the videojs library
-          // else if (!videoNode.current?.paused) {
-          //   videoNode.current?.pause();
-          // }
         }
       });
     };
@@ -89,15 +87,20 @@ const VideoPlayer: React.FC<IVideoPlayerProps> = ({
   return (
     <>
       {/* <link> lets us preload videos without blocking DOM */}
-      <link rel="preload" as="video" href={videoSrc} />
-      {/* <video preload="none"> because we don't want to spam max HTTP connections to same domain (HTTP 1.1-6 spec)
+      <link
+        key={`preload-link-${videoPlayerId}`}
+        rel="preload"
+        as="video"
+        href={videoSrc}
+      />
+      {/* we do not set <video preload="auto"> because we don't want to spam max HTTP connections to same domain (HTTP 1.1-6 spec)
           this improves load speed significantly
       */}
       <div id={videoPlayerWrapperId} ref={wrapperRef}>
         <video
           id={videoPlayerId}
           muted
-          preload="none"
+          preload="metadata"
           autoPlay={false}
           ref={videoNode}
           className="video-js"

--- a/frontend/src/@components/videoplayer/index.tsx
+++ b/frontend/src/@components/videoplayer/index.tsx
@@ -8,6 +8,7 @@ interface IVideoPlayerProps {
   options: videojs.PlayerOptions;
   thumbnail?: string | null;
   videoSrc: string;
+  sceneId: string;
 }
 
 const initialOptions: videojs.PlayerOptions = {
@@ -24,9 +25,41 @@ const VideoPlayer: React.FC<IVideoPlayerProps> = ({
   options,
   thumbnail,
   videoSrc,
+  sceneId,
 }) => {
   const videoNode = React.useRef<HTMLVideoElement>(null);
   const player = React.useRef<videojs.Player>();
+
+  const videoPlayerId = `videoplayer-${sceneId}`;
+
+  useEffect(() => {
+    const intersectionObserverOptions = {
+      // root=null means the viewport will be the window
+      root: null,
+      rootMargin: "0px",
+      // how much of the video must appear in viewport in order to play
+      threshold: 1.0,
+    };
+    const intersectionObserverCallback: IntersectionObserverCallback = (
+      entries,
+      observer
+    ) => {
+      entries.forEach((entry) => {
+        if (entry.target.id === videoPlayerId) {
+          if (entry.isIntersecting) {
+            (entry.target as HTMLVideoElement).play();
+          } else {
+            (entry.target as HTMLVideoElement).pause();
+          }
+        }
+      });
+    };
+    const observer = new IntersectionObserver(
+      intersectionObserverCallback,
+      intersectionObserverOptions
+    );
+    observer.observe(videoNode as unknown as HTMLElement);
+  }, [videoPlayerId]);
 
   useEffect(() => {
     player.current = videojs(videoNode.current || "", {
@@ -55,9 +88,10 @@ const VideoPlayer: React.FC<IVideoPlayerProps> = ({
           this improves load speed significantly
       */}
       <video
+        id={videoPlayerId}
         muted
         preload="none"
-        autoPlay
+        autoPlay={false}
         ref={videoNode}
         className="video-js"
         {...videoAttrs}

--- a/frontend/src/@components/videoplayer/index.tsx
+++ b/frontend/src/@components/videoplayer/index.tsx
@@ -93,14 +93,14 @@ const VideoPlayer: React.FC<IVideoPlayerProps> = ({
         as="video"
         href={videoSrc}
       />
-      {/* we do not set <video preload="auto"> because we don't want to spam max HTTP connections to same domain (HTTP 1.1-6 spec)
+      {/* we do not set <video preload="none"> because we don't want to spam max HTTP connections to same domain (HTTP 1.1-6 spec)
           this improves load speed significantly
       */}
       <div id={videoPlayerWrapperId} ref={wrapperRef}>
         <video
           id={videoPlayerId}
           muted
-          preload="metadata"
+          preload="none"
           autoPlay={false}
           ref={videoNode}
           className="video-js"

--- a/frontend/src/@components/videoplayer/index.tsx
+++ b/frontend/src/@components/videoplayer/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useEffect } from "react";
 import videojs from "video.js";
 
 // Styles
@@ -6,6 +6,8 @@ import "video.js/dist/video-js.css";
 
 interface IVideoPlayerProps {
   options: videojs.PlayerOptions;
+  thumbnail?: string | null;
+  videoSrc: string;
 }
 
 const initialOptions: videojs.PlayerOptions = {
@@ -18,11 +20,15 @@ const initialOptions: videojs.PlayerOptions = {
   },
 };
 
-const VideoPlayer: React.FC<IVideoPlayerProps> = ({ options }) => {
+const VideoPlayer: React.FC<IVideoPlayerProps> = ({
+  options,
+  thumbnail,
+  videoSrc,
+}) => {
   const videoNode = React.useRef<HTMLVideoElement>(null);
   const player = React.useRef<videojs.Player>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     player.current = videojs(videoNode.current || "", {
       ...initialOptions,
       ...options,
@@ -36,7 +42,28 @@ const VideoPlayer: React.FC<IVideoPlayerProps> = ({ options }) => {
     };
   }, [options]);
 
-  return <video muted autoPlay ref={videoNode} className="video-js" />;
+  const videoAttrs: { poster?: string } = {};
+  if (thumbnail) {
+    videoAttrs.poster = thumbnail;
+  }
+
+  return (
+    <>
+      {/* <link> lets us preload videos without blocking DOM */}
+      <link rel="preload" as="video" href={videoSrc} />
+      {/* <video preload="none"> because we don't want to spam max HTTP connections to same domain (HTTP 1.1-6 spec)
+          this improves load speed significantly
+      */}
+      <video
+        muted
+        preload="none"
+        autoPlay
+        ref={videoNode}
+        className="video-js"
+        {...videoAttrs}
+      />
+    </>
+  );
 };
 
 export default VideoPlayer;


### PR DESCRIPTION
Videos play & pause depending on if they are on the screen.
Attempted to preload resources using `<link ref="preload">` as to not block the DOM, but it appears that we are still requesting resources each time in the Networks tab. Using `<video preload="auto">` behaves the same too.